### PR TITLE
Upgrade pre-commit python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
       shellcheck \
       zlib1g-dev
 
-RUN pip install pre-commit==0.13.3
+RUN pip install pre-commit==0.15.2
 
 RUN mkdir /pre-commit
 COPY .pre-commit-config-for-build.yaml /pre-commit/.pre-commit-config.yaml


### PR DESCRIPTION
Upgrade to latest `pre-commit` python version available on PyPI.

Docker Hub build failed with the following error after PR merge #3 

```
[ERROR] The hook `reorder-python-imports` requires pre-commit version 0.15.0 but version 0.13.3 is installed.  Perhaps run `pip install --upgrade pre-commit`.
```