### PR TITLE
Upgrade and pin 'shellcheck' version to match Homebrew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 # Use specific version of shellcheck. It's useful to keep
 # this in sync with the version in Homebrew so macOS developer
 # workstations have the same version as this Docker image.
-ARG SHELLCHECK_VERSION=0.5.0
+ARG SHELLCHECK_VERSION=0.6.0
 RUN mkdir /tmp/shellcheck && \
     cd /tmp/shellcheck && \
     curl -# -O "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,22 @@ RUN apt-get update && apt-get install -y \
       nodejs \
       ruby \
       ruby-dev \
-      shellcheck \
       unzip \
+      xz-utils \
       zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt
+
+# Use specific version of shellcheck. It's useful to keep
+# this in sync with the version in Homebrew so macOS developer
+# workstations have the same version as this Docker image.
+ARG SHELLCHECK_VERSION=0.5.0
+RUN mkdir /tmp/shellcheck && \
+    cd /tmp/shellcheck && \
+    curl -# -O "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" && \
+    tar --xz -xvf shellcheck-v"${SHELLCHECK_VERSION}".linux.x86_64.tar.xz && \
+    cp shellcheck-v"${SHELLCHECK_VERSION}"/shellcheck /usr/bin/ && \
+    rm -rf /tmp/shellcheck
 
 RUN mkdir -p /tmp/terraform && \
     cd /tmp/terraform && \


### PR DESCRIPTION
We were previously using shellcheck `v0.4.4` which is what was installed via `apt`. Since this isn't the version that most macOS users are on we have a drift between CI and dev workstations.

This pins this Docker image to `v0.6.0` which is what is currently in Homebrew:
https://github.com/Homebrew/homebrew-core/blob/53fc2f730f3d75df74111ec29d6af0d2e2de5102/Formula/shellcheck.rb